### PR TITLE
Manage log_level variable in the vrouter agent

### DIFF
--- a/opencontrail/files/3.0/contrail-vrouter-agent.conf
+++ b/opencontrail/files/3.0/contrail-vrouter-agent.conf
@@ -41,7 +41,7 @@ log_file=/var/log/contrail/contrail-vrouter-agent.log
 
 # Log severity levels. Possible values are SYS_EMERG, SYS_ALERT, SYS_CRIT, 
 # SYS_ERR, SYS_WARN, SYS_NOTICE, SYS_INFO and SYS_DEBUG. Default is SYS_DEBUG
-log_level=SYS_NOTICE
+log_level={{ compute.vrouter_log_level.get('level', 'SYS_NOTICE') }}
 
 # Enable/Disable local file logging. Possible values are 0 (disable) and 1 (enable)
 log_local=1


### PR DESCRIPTION
Currently this variable is statically set. We would like to change this on the computes, let's create a variable for it and manage it that way.